### PR TITLE
[FEATURE] Added nginx_status ENV

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,6 @@ RUN \
 
 ADD container-files /
 
+ENV STATUS_PAGE_ALLOWED_IP=127.0.0.1
+
 EXPOSE 80 443

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 This is a [million12/nginx](https://registry.hub.docker.com/u/million12/nginx/) docker container with Nginx web server, nicely tuned for a better performance.
 
-Things included:
+# Features
 
 ##### - directory structure
 ```
@@ -23,9 +23,19 @@ Nginx `error_log` is set to `stderr` and therefore Nginx log is available only v
 
 This is probably best approach if you'd like to source your logs from outside the container (e.g. via `docker logs` or CoreOS `journald') and you don't want to worry about logging and log management inside your container.
 
-#### - graceful reload after config change
+##### - graceful reload after config change
 
 Folders `/etc/nginx/` and `/data/conf/nginx/` are monitored for any config changes and, when they happen, Nginx is gracefully reloaded.
+
+##### - Nginx status page
+
+Nginx status page is configured under `/nginx_status` URL on the default vhost. Also see `STATUS_PAGE_ALLOWED_IP` env variable described below.
+Eample output:  
+	
+	Active connections: 1 
+	server accepts handled requests
+	11475 11475 13566 
+	Reading: 0 Writing: 1 Waiting: 0
 
 
 ## Usage
@@ -76,10 +86,16 @@ Default: `SET_INTERNAL_HTTPS_PROXY_ON_PORT=null`
 Example: `SET_INTERNAL_HTTPS_PROXY_ON_PORT=3000`  
 Similar to `SET_INTERNAL_PROXY_ON_PORT`, but the proxy then listens with SSL support and proxies the request to HTTPS as well. Note: if you use both, `SET_INTERNAL_PROXY_ON_PORT` and `SET_INTERNAL_HTTPS_PROXY_ON_PORT` options (to have HTTP and HTTPS support), you of course need to use two different port numbers.
 
+**STATUS_PAGE_ALLOWED_IP**  
+Default: `STATUS_PAGE_ALLOWED_IP=127.0.0.1`  
+Example: `STATUS_PAGE_ALLOWED_IP=10.1.1.0/16`  
+Configure ip address that would be allowed to see nginx status page on `/nginx_status` URL.  
+
+
 ## Authors
 
-Author: ryzy (<marcin@m12.io>)  
-Author: pozgo (<linux@ozgo.info>)
+Author: Marcin Ryzycki (<marcin@m12.io>)  
+Author: Przemyslaw Ozgo (<linux@ozgo.info>)
 
 ---
 

--- a/circle.yml
+++ b/circle.yml
@@ -3,18 +3,11 @@ machine:
     - docker
 
 dependencies:
-  pre:
-    - docker info && docker version
-    
   override:
-    - docker pull million12/centos-supervisor:latest
+    - docker build -t million12/nginx .
 
 # Run tests
 test:
-  pre:
-    # Build million12/nginx image
-    - docker build -t million12/nginx .
-
   override:
     - docker run -d -p 8080:80 --name nginx million12/nginx
     - while true; do if docker logs nginx | grep "nginx entered RUNNING state"; then break; else sleep 1; fi done
@@ -47,8 +40,22 @@ test:
     #
     # Test internal proxy
     #
-    - docker run -d -p 8282:80 -p 3000:3000 --env="SET_INTERNAL_PROXY_ON_PORT=3000" million12/nginx && sleep 5
+    - docker run -d --name nginx-proxy -p 8282:80 -p 3000:3000 --env="SET_INTERNAL_PROXY_ON_PORT=3000" million12/nginx && sleep 5
     - curl -s --show-error -o out.log http://localhost:8282 > out.log 2>&1
     - curl -s --show-error -o out-proxy.log http://localhost:3000 > out-proxy.log 2>&1
     - grep 'default vhost' out.log
     - grep 'default vhost' out-proxy.log
+    - docker rm -f nginx-proxy || true
+
+    #
+    # Test /nginx_status page
+    #
+    - docker run -d --name nginx-status -p 8383:80 million12/nginx && sleep 5
+    - curl -sSLi http://localhost:8383/nginx_status/ | grep "HTTP/1.1 403 Forbidden"
+    - docker rm -f nginx-status || true
+    
+    - docker run -d --name nginx-status -p 8383:80 --env="STATUS_PAGE_ALLOWED_IP=$(ip -4 addr show docker0 | grep inet | cut -d/ -f1 | awk '{print $2}')" million12/nginx && sleep 5
+    - curl -sSLi http://localhost:8383/nginx_status/
+    - curl -sSLi http://localhost:8383/nginx_status/ | grep "HTTP/1.1 200 OK"
+    - curl -sSLi http://localhost:8383/nginx_status/ | grep "Active connections"
+    - docker rm -f nginx-status || true

--- a/container-files/config/init/10-nginx-stub-status.sh
+++ b/container-files/config/init/10-nginx-stub-status.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+#
+# Configure access IP address for nginx status page under /nginx_status
+#
+sed -i "s|allow 127.0.0.1|allow ${STATUS_PAGE_ALLOWED_IP}|g" /etc/nginx/conf.d/stub-status.conf
+echo "Nginx status page: allowed address set to: $STATUS_PAGE_ALLOWED_IP"; echo

--- a/container-files/etc/nginx/conf.d/stub-status.conf
+++ b/container-files/etc/nginx/conf.d/stub-status.conf
@@ -1,0 +1,5 @@
+location /nginx_status {
+  stub_status;
+  allow 127.0.0.1;
+  deny all;
+}

--- a/container-files/etc/nginx/hosts.d/default.conf
+++ b/container-files/etc/nginx/hosts.d/default.conf
@@ -3,6 +3,8 @@ server {
   root        /data/www/default;
   index       index.html;
   
+  include     /etc/nginx/conf.d/stub-status.conf;
+  
   include     /etc/nginx/conf.d/default-*.conf;
   include     /data/conf/nginx/conf.d/default-*.conf;
 }


### PR DESCRIPTION
By default /nginx_status is allowed only from localhost. 
